### PR TITLE
Use spid-testenv-identityserver instead of idp.spid.gov.it

### DIFF
--- a/spid-confs/conf/identity/application-authentication.xml
+++ b/spid-confs/conf/identity/application-authentication.xml
@@ -144,9 +144,9 @@
         -->
 
 	<AuthenticatorConfig name="EmailOTP" enabled="true">
-		<Parameter name="EMAILOTPAuthenticationEndpointURL">https://idp.spid.gov.it:9443/emailotpauthenticationendpoint/emailotp.jsp</Parameter>
-		<Parameter name="EmailOTPAuthenticationEndpointErrorPage">https://idp.spid.gov.it:9443/emailotpauthenticationendpoint/emailotpError.jsp</Parameter>
-		<Parameter name="EmailAddressRequestPage">https://idp.spid.gov.it:9443/emailotpauthenticationendpoint/emailAddress.jsp</Parameter>
+		<Parameter name="EMAILOTPAuthenticationEndpointURL">https://spid-testenv-identityserver:9443/emailotpauthenticationendpoint/emailotp.jsp</Parameter>
+		<Parameter name="EmailOTPAuthenticationEndpointErrorPage">https://spid-testenv-identityserver:9443/emailotpauthenticationendpoint/emailotpError.jsp</Parameter>
+		<Parameter name="EmailAddressRequestPage">https://spid-testenv-identityserver:9443/emailotpauthenticationendpoint/emailAddress.jsp</Parameter>
 		<Parameter name="usecase">local</Parameter>
 		<Parameter name="secondaryUserstore">primary</Parameter>
 		<Parameter name="EMAILOTPMandatory">false</Parameter>


### PR DESCRIPTION
In the [README of the spid-testenv-docker repository](https://github.com/italia/spid-testenv-docker/blob/master/README.md) we say that we should use `spid-testenv-identityserver` for the test server name.